### PR TITLE
parse addDefinition version as integer for compat

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -1528,7 +1528,7 @@
 		"node_modules/tera-proxy-game/clients/RealClient.js": "CaNIwr3438EX8bq7QkYp6DqqA9s+DwLCZJTyTOHKF90=",
 		"node_modules/tera-proxy-game/compat.js": "LnlGIlZWHrwnrH5yOlmcRS8EiJgRFsX4WsVfXb+LaQ0=",
 		"node_modules/tera-proxy-game/connection/dispatch/hotswap.js": "YnvlsyGP7s7KxFvDP2CJGvXxL1el+IYCpmeaVukSN+I=",
-		"node_modules/tera-proxy-game/connection/dispatch/index.js": "PhwWiDcMfhdJyGpRkbvVk/uzWr7E+/MGThSqUpDd1oI=",
+		"node_modules/tera-proxy-game/connection/dispatch/index.js": "ZUOHP4LEzYCSmopbJiU/hnBaN+T+MtUI2Re3zFQIkgg=",
 		"node_modules/tera-proxy-game/connection/dispatch/settings.js": "9mIo0xgs8LfYhBv0hyFY3BkMlkZER0q4v+T3JRNp1tI=",
 		"node_modules/tera-proxy-game/connection/dispatch/wrapper.js": "opwB+nfKL5mHNL0tj8nyhZAu+X+3zpPX9dHQMiKt4pg=",
 		"node_modules/tera-proxy-game/connection/encryption/index.js": "6MxG3SaEb21gJ+D+V2Vemp2gcO+VtZq6fhBHupO44s0=",

--- a/node_modules/tera-proxy-game/connection/dispatch/index.js
+++ b/node_modules/tera-proxy-game/connection/dispatch/index.js
@@ -347,6 +347,8 @@ class Dispatch extends EventEmitter {
 
 	// name, version, file
 	addDefinition(name, version, file) {
+		version = parseInt(version, 10)
+		if (isNaN(version)) throw Error(`Cannot add definition ${name} (version must be an integer)`)
 		const versions = TeraProtocol.defs.get(name)
 		if(versions && versions.has(version)) return
 


### PR DESCRIPTION
This will fix a compatibility issue with `mod.dispatch.addDefinition` not converting the version parameter of a custom def to an integer like toolbox.
It's easy enough to work around but it shouldn't be too much effort to address in tera-proxy-game.

More Info on this issue here [Issue: #21](https://github.com/Kloct/tera-client/issues/21)